### PR TITLE
Fix timeout condition

### DIFF
--- a/simple-mdns/CHANGELOG.md
+++ b/simple-mdns/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Simple MDNS
+## Unreleased
+- Fix timeout condition
+
 ## 0.3.6
 - Update dependencies
 

--- a/simple-mdns/src/oneshot_resolver.rs
+++ b/simple-mdns/src/oneshot_resolver.rs
@@ -180,7 +180,7 @@ impl OneShotMdnsResolver {
                     }
                 }
                 Err(_) => {
-                    if query_deadline > std::time::Instant::now() {
+                    if std::time::Instant::now() > query_deadline {
                         return Ok(None);
                     }
                 }


### PR DESCRIPTION
Currently timeout condition leads to instant return from `query_service_address_and_port`. This PR fixes the issue.