### PR TITLE
rfc6891 / EDNS support

### DIFF
--- a/simple-dns/src/dns/packet.rs
+++ b/simple-dns/src/dns/packet.rs
@@ -4,6 +4,8 @@ use crate::{SimpleDnsError, OPCODE};
 
 use super::{PacketHeader, PacketPart, Question, ResourceRecord};
 
+use super::resource_record::ClassOrPayload;
+
 /// Owned version of [`Packet`] that contains a internal buffer.  
 /// This struct fills the internal buffer on the fly, because of this, it imposes some constraints.  
 /// You have to build the packet in order.  
@@ -395,7 +397,7 @@ mod tests {
         assert_eq!(11, packet.answers.len());
 
         assert_eq!("google.com", packet.answers[0].name.to_string());
-        assert_eq!(CLASS::IN, packet.answers[0].class);
+        assert_eq!(ClassOrPayload::Class(CLASS::IN), packet.answers[0].class_or_payload);
         assert_eq!(4, packet.answers[0].ttl);
         assert_eq!(4, packet.answers[0].rdata.len());
 

--- a/simple-dns/src/dns/resource_record.rs
+++ b/simple-dns/src/dns/resource_record.rs
@@ -202,7 +202,7 @@ mod tests {
         let rr = ResourceRecord::parse(&bytes[..], 0).unwrap();
 
         assert_eq!("_srv._udp.local", rr.name.to_string());
-        assert_eq!(CLASS::IN, rr.class);
+        assert_eq!(ClassOrPayload::Class(CLASS::IN), rr.class_or_payload);
         assert_eq!(10, rr.ttl);
         assert_eq!(4, rr.rdata.len());
         assert!(!rr.cache_flush);
@@ -218,7 +218,7 @@ mod tests {
         let bytes = b"\x04_srv\x04_udp\x05local\x00\x00\x01\x80\x01\x00\x00\x00\x0a\x00\x04\xff\xff\xff\xff";
         let rr = ResourceRecord::parse(&bytes[..], 0).unwrap();
 
-        assert_eq!(CLASS::IN, rr.class);
+        assert_eq!(ClassOrPayload::Class(CLASS::IN), rr.class_or_payload);
         assert!(rr.cache_flush);
     }
 
@@ -228,7 +228,7 @@ mod tests {
         let rdata = [255u8; 4];
 
         let rr = ResourceRecord {
-            class: CLASS::IN,
+            class_or_payload: ClassOrPayload::Class(CLASS::IN),
             name: "_srv._udp.local".try_into().unwrap(),
             ttl: 10,
             rdata: RData::NULL(0, NULL::new(&rdata).unwrap()),
@@ -249,7 +249,7 @@ mod tests {
         let rdata = [255u8; 4];
 
         let rr = ResourceRecord {
-            class: CLASS::IN,
+            class_or_payload: ClassOrPayload::Class(CLASS::IN),
             name: "_srv._udp.local".try_into().unwrap(),
             ttl: 10,
             rdata: RData::NULL(0, NULL::new(&rdata).unwrap()),
@@ -267,7 +267,7 @@ mod tests {
     #[test]
     fn test_match_qclass() {
         let rr = ResourceRecord {
-            class: CLASS::IN,
+            class_or_payload: ClassOrPayload::Class(CLASS::IN),
             name: "_srv._udp.local".try_into().unwrap(),
             ttl: 10,
             rdata: RData::NULL(0, NULL::new(&[255u8; 4]).unwrap()),
@@ -282,7 +282,7 @@ mod tests {
     #[test]
     fn test_match_qtype() {
         let rr = ResourceRecord {
-            class: CLASS::IN,
+            class_or_payload: ClassOrPayload::Class(CLASS::IN),
             name: "_srv._udp.local".try_into().unwrap(),
             ttl: 10,
             rdata: RData::A(crate::rdata::A { address: 0 }),
@@ -297,7 +297,7 @@ mod tests {
     #[test]
     fn test_match_qtype_for_aaaa() {
         let mut rr = ResourceRecord {
-            class: CLASS::IN,
+            class_or_payload: ClassOrPayload::Class(CLASS::IN),
             name: "_srv._udp.local".try_into().unwrap(),
             ttl: 10,
             rdata: RData::A(crate::rdata::A { address: 0 }),

--- a/simple-dns/src/dns/resource_record.rs
+++ b/simple-dns/src/dns/resource_record.rs
@@ -58,12 +58,7 @@ impl<'a> ResourceRecord<'a> {
     /// Return true if current resource match given query class
     pub fn match_qclass(&self, qclass: QCLASS) -> bool {
         match qclass {
-            QCLASS::CLASS(class) => {
-                match self.class_or_payload {
-                    ClassOrPayload::Class(rr_class) => class == rr_class,
-                    _ => false,
-                }
-            },
+            QCLASS::CLASS(class) => ClassOrPayload::Class(class) == self.class_or_payload,
             QCLASS::ANY => true,
         }
     }
@@ -115,17 +110,17 @@ impl<'a> PacketPart<'a> for ResourceRecord<'a> {
         let rdata = RData::parse(data, offset)?;
 
         if name.get_labels().len() == 0
-            && u16::from_be_bytes(data[offset..offset+2].try_into()?) == 41 {
-                // is EDNS OPT RR
-                Ok(Self {
-                    name,
-                    class_or_payload: ClassOrPayload::Payload(class_value),
-                    ttl,
-                    rdata,
-                    cache_flush: false,
-                })
-            }
-        else {
+            && u16::from_be_bytes(data[offset..offset + 2].try_into()?) == 41
+        {
+            // is EDNS OPT RR
+            Ok(Self {
+                name,
+                class_or_payload: ClassOrPayload::Payload(class_value),
+                ttl,
+                rdata,
+                cache_flush: false,
+            })
+        } else {
             let cache_flush = class_value & flag::CACHE_FLUSH == flag::CACHE_FLUSH;
             let class = (class_value & !flag::CACHE_FLUSH).try_into()?;
 
@@ -136,7 +131,6 @@ impl<'a> PacketPart<'a> for ResourceRecord<'a> {
                 rdata,
                 cache_flush,
             })
-
         }
     }
 
@@ -181,7 +175,9 @@ impl<'a> Hash for ResourceRecord<'a> {
 
 impl<'a> PartialEq for ResourceRecord<'a> {
     fn eq(&self, other: &Self) -> bool {
-        self.name == other.name && self.class_or_payload == other.class_or_payload && self.rdata == other.rdata
+        self.name == other.name
+            && self.class_or_payload == other.class_or_payload
+            && self.rdata == other.rdata
     }
 }
 


### PR DESCRIPTION
first, thanks for your work so far on this library!

i have a simple application receiving mDNS messages and immediately started getting messages on my network that were failing to parse with a similar message as described in issue #5 even though my application is happy to ignore the extra data.

before pushing too far down a particular implementation approach, i wanted to see whether it would be worth pursuing. i could see a couple of potential paths:
* adding a "PseudoResourceRecord" type plus an enum with variants for that type and `ResourceRecord`, so `Packet.additional_records` would be a Vec of those enums, or
* stick with the approach started here, but clean it up... maybe even just make a variant of `CLASS` ("EDNS_OPT"?) that holds the payload len value, etc.

your thoughts?