### PR TITLE
options to specify Ipv4 network interface

### DIFF
--- a/simple-mdns/README.md
+++ b/simple-mdns/README.md
@@ -8,10 +8,10 @@ It is necessary to provide instance and service name
 
 ```rust  
     use simple_mdns::ServiceDiscovery;
-    use std::net::SocketAddr;
+    use std::net::{SocketAddr, Ipv4Addr};
     use std::str::FromStr;
 
-    let mut discovery = ServiceDiscovery::new("a", "_mysrv._tcp.local", 60).expect("Invalid Service Name");
+    let mut discovery = ServiceDiscovery::new("a", "_mysrv._tcp.local", 60, &Ipv4Addr::UNSPECIFIED).expect("Invalid Service Name");
     discovery.add_service_info(SocketAddr::from_str("192.168.1.22:8090").unwrap().into());
 ```
 
@@ -29,7 +29,9 @@ Since mDNS is a well known protocol, you can register your service in any mDNS r
 Query example:
 ```rust  
     use simple_mdns::OneShotMdnsResolver;
-    let resolver = OneShotMdnsResolver::new().expect("Failed to create resolver");
+    use std::net::Ipv4Addr;
+
+    let resolver = OneShotMdnsResolver::new(&Ipv4Addr::UNSPECIFIED).expect("Failed to create resolver");
     // querying for IP Address
     let answer = resolver.query_service_address("_myservice._tcp.local").expect("Failed to query service address");
     println!("{:?}", answer);
@@ -53,7 +55,7 @@ This struct relies on [`simple-dns`](https://crates.io/crates/simple-dns) crate 
     use std::net::Ipv4Addr;
 
 
-    let mut responder = SimpleMdnsResponder::new(10);
+    let mut responder = SimpleMdnsResponder::new(10, &Ipv4Addr::UNSPECIFIED);
     let srv_name = Name::new_unchecked("_srvname._tcp.local");
 
     responder.add_resource(ResourceRecord::new(

--- a/simple-mdns/src/dns_packet_receiver.rs
+++ b/simple-mdns/src/dns_packet_receiver.rs
@@ -1,4 +1,4 @@
-use std::net::{SocketAddr, UdpSocket};
+use std::net::{SocketAddr, UdpSocket, Ipv4Addr};
 
 use simple_dns::{PacketBuf, PacketHeader};
 
@@ -10,8 +10,8 @@ pub struct DnsPacketReceiver {
 }
 
 impl DnsPacketReceiver {
-    pub fn new() -> Result<Self, SimpleMdnsError> {
-        let recv_socket = join_multicast(&MULTICAST_IPV4_SOCKET)?;
+    pub fn new(interface: &Ipv4Addr) -> Result<Self, SimpleMdnsError> {
+        let recv_socket = join_multicast(&MULTICAST_IPV4_SOCKET, interface)?;
         let _ = recv_socket.set_read_timeout(None);
         let recv_buffer = [0u8; 9000];
 

--- a/simple-mdns/src/lib.rs
+++ b/simple-mdns/src/lib.rs
@@ -53,7 +53,7 @@ fn create_socket(addr: &SocketAddr) -> io::Result<Socket> {
     Ok(socket)
 }
 
-fn join_multicast(addr: &SocketAddr) -> io::Result<UdpSocket> {
+fn join_multicast(addr: &SocketAddr, interface: &Ipv4Addr) -> io::Result<UdpSocket> {
     let ip_addr = addr.ip();
 
     let socket = create_socket(addr)?;
@@ -61,7 +61,7 @@ fn join_multicast(addr: &SocketAddr) -> io::Result<UdpSocket> {
     // depending on the IP protocol we have slightly different work
     match ip_addr {
         IpAddr::V4(ref mdns_v4) => {
-            socket.join_multicast_v4(mdns_v4, &Ipv4Addr::UNSPECIFIED)?;
+            socket.join_multicast_v4(mdns_v4, interface)?;
         }
         IpAddr::V6(ref mdns_v6) => {
             socket.join_multicast_v6(mdns_v6, 0)?;
@@ -94,11 +94,11 @@ fn bind_multicast(socket: Socket, addr: &SocketAddr) -> io::Result<Socket> {
     Ok(socket)
 }
 
-fn sender_socket(addr: &SocketAddr) -> io::Result<UdpSocket> {
+fn sender_socket(addr: &SocketAddr, interface: &Ipv4Addr) -> io::Result<UdpSocket> {
     let socket = create_socket(addr)?;
     if addr.is_ipv4() {
         socket.bind(&SockAddr::from(SocketAddr::new(
-            Ipv4Addr::UNSPECIFIED.into(),
+            IpAddr::V4(*interface).into(),
             0,
         )))?;
     } else {

--- a/simple-mdns/tests/service_discovery_tests.rs
+++ b/simple-mdns/tests/service_discovery_tests.rs
@@ -1,5 +1,5 @@
 use simple_mdns::{InstanceInformation, ServiceDiscovery};
-use std::{collections::HashMap, error::Error, net::SocketAddr, str::FromStr, time::Duration};
+use std::{collections::HashMap, error::Error, net::{SocketAddr, Ipv4Addr}, str::FromStr, time::Duration};
 
 // fn init_log() {
 //     stderrlog::new()
@@ -9,15 +9,17 @@ use std::{collections::HashMap, error::Error, net::SocketAddr, str::FromStr, tim
 //         .unwrap();
 // }
 
+const INTERFACE: &Ipv4Addr = &Ipv4Addr::UNSPECIFIED;
+
 #[test]
 fn service_discovery_can_find_services() -> Result<(), Box<dyn Error>> {
     // init_log();
 
     std::thread::sleep(Duration::from_secs(1));
 
-    let mut service_discovery_a = ServiceDiscovery::new("a", "_srv3._tcp.local", 60)?;
-    let mut service_discovery_b = ServiceDiscovery::new("b", "_srv3._tcp.local", 60)?;
-    let mut service_discovery_c = ServiceDiscovery::new("c", "_srv3._tcp.local", 60)?;
+    let mut service_discovery_a = ServiceDiscovery::new("a", "_srv3._tcp.local", 60, INTERFACE)?;
+    let mut service_discovery_b = ServiceDiscovery::new("b", "_srv3._tcp.local", 60, INTERFACE)?;
+    let mut service_discovery_c = ServiceDiscovery::new("c", "_srv3._tcp.local", 60, INTERFACE)?;
 
     service_discovery_a
         .add_service_info(SocketAddr::from_str("192.168.1.2:8080")?.into())
@@ -74,8 +76,8 @@ fn service_discovery_receive_attributes() -> Result<(), Box<dyn Error>> {
 
     std::thread::sleep(Duration::from_secs(1));
 
-    let mut service_discovery_d = ServiceDiscovery::new("d", "_srv4._tcp.local", 60)?;
-    let mut service_discovery_e = ServiceDiscovery::new("e", "_srv4._tcp.local", 60)?;
+    let mut service_discovery_d = ServiceDiscovery::new("d", "_srv4._tcp.local", 60, INTERFACE)?;
+    let mut service_discovery_e = ServiceDiscovery::new("e", "_srv4._tcp.local", 60, INTERFACE)?;
 
     let mut service_info: InstanceInformation = SocketAddr::from_str("192.168.1.2:8080")?.into();
     service_info


### PR DESCRIPTION
Hi there,

I added the option to specify an Ipv4 network interface for simple-mdns. This is useful for setups where there is more than one Ipv4 network interface.
You can use `&Ipv4Addr::UNSPECIFIED` and let the os choose or use an ip address that is associated with an interface.
