### PR TITLE
fix traits of PacketFlag struct

### DIFF
--- a/simple-dns/src/dns/mod.rs
+++ b/simple-dns/src/dns/mod.rs
@@ -36,7 +36,7 @@ const MAX_NULL_LENGTH: usize = 65535;
 
 bitflags! {
     /// Possible Packet Flags
-    #[derive(Debug, Clone)]
+    #[derive(Clone, Debug, PartialEq, Copy)]
     pub struct PacketFlag: u16 {
         /// Indicates if this packet is a query or a response. This is the QR flag in the DNS
         /// specifications, this flag is called Response here to be more ergonomic


### PR DESCRIPTION
see #19 - this adds back the previously automatically derived traits of the bitflags macro