### PR TITLE
Adding NAPTR Record

### DIFF
--- a/simple-dns/src/dns/rdata/mod.rs
+++ b/simple-dns/src/dns/rdata/mod.rs
@@ -36,6 +36,9 @@ pub use minfo::MINFO;
 mod mx;
 pub use mx::MX;
 
+mod naptr;
+pub use naptr::NAPTR;
+
 mod nsap;
 pub use nsap::NSAP;
 
@@ -148,6 +151,7 @@ macros::rdata_enum! {
     AFSDB<'a>,
     ISDN<'a>,
     RouteThrough<'a>,
+    NAPTR<'a>,
     NSAP,
     NSAP_PTR<'a>,
     LOC,

--- a/simple-dns/src/dns/rdata/naptr.rs
+++ b/simple-dns/src/dns/rdata/naptr.rs
@@ -64,7 +64,7 @@ impl<'a> PacketPart<'a> for NAPTR<'a> {
         out.write_all(&self.preference.to_be_bytes())?;
         self.flags.write_to(out)?;
         self.services.write_to(out)?;
-        self.regexp.write_to(regexp)?;
+        self.regexp.write_to(out)?;
         self.replacement.write_to(out)
     }
 

--- a/simple-dns/src/dns/rdata/naptr.rs
+++ b/simple-dns/src/dns/rdata/naptr.rs
@@ -101,6 +101,6 @@ mod tests {
         assert_eq!("123abc", naptr.flags.to_string());
         assert_eq!("test", naptr.services.to_string());
         assert_eq!("@\\w+\\.\\w{2,3}(\\.\\w{2,3})?", naptr.regexp.to_string());
-        assert_eq!("e.exchange.com", naptr.value.to_string());
+        assert_eq!("e.exchange.com", naptr.replacement.to_string());
     }
 }

--- a/simple-dns/src/dns/rdata/naptr.rs
+++ b/simple-dns/src/dns/rdata/naptr.rs
@@ -1,4 +1,4 @@
-use crate::dns::{CharacterString, PacketPart};
+use crate::dns::{CharacterString, Name, PacketPart};
 
 use super::RR;
 
@@ -47,9 +47,9 @@ impl<'a> PacketPart<'a> for NAPTR<'a> {
     where
         Self: Sized,
     {
-        let order = u8::from_be_bytes(data[*position..*position + 1].try_into()?);
+        let order = u16::from_be_bytes(data[*position..*position + 1].try_into()?);
         *position += 1;
-        let preference = u8::from_be_bytes(data[*position..*position + 1].try_into()?);
+        let preference = u16::from_be_bytes(data[*position..*position + 1].try_into()?);
         *position += 1;
         let flags = CharacterString::parse(data, position)?;
         let services = CharacterString::parse(data, position)?;

--- a/simple-dns/src/dns/rdata/naptr.rs
+++ b/simple-dns/src/dns/rdata/naptr.rs
@@ -1,0 +1,106 @@
+use crate::dns::{CharacterString, PacketPart};
+
+use super::RR;
+
+/// RFC 3403: Used to map a domain name to a set of services. The fields determine 
+///           the order of processing, specify the protocol and service to be used,
+///           and transform the original domain name into a new domain name or URI.
+
+
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub struct NAPTR<'a> {
+    /// Order in which NAPTR records must be processed
+    pub order: u16,
+    /// Order in which NAPTR records with equal Order values should be processed
+    pub preference: u16,
+    /// Control rewriting and interpretation of the fields in the record
+    pub flags: CharacterString<'a>,
+    /// Service Parameters applicable to this this delegation path
+    pub services: CharacterString<'a>,
+    /// Regular expression applied to original string from client
+    pub regexp: CharacterString<'a>,
+    /// Next domain-name to query for
+    pub replacement: Name<'a>,
+}
+
+impl<'a> RR for NAPTR<'a> {
+    const TYPE_CODE: u16 = 35;
+}
+
+impl<'a> NAPTR<'a> {
+    /// Transforms the inner data into it owned type
+    pub fn into_owned<'b>(self) -> NAPTR<'b> {
+        NAPTR {
+            order: self.order,
+            preference: self.preference,
+            flags: self.flags.into_owned(),
+            services: self.services.into_owned(),
+            regexp: self.regexp.into_owned(),
+            replacement: self.replacement.into_owned(),
+        }
+    }
+}
+
+impl<'a> PacketPart<'a> for NAPTR<'a> {
+    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
+    where
+        Self: Sized,
+    {
+        let order = u8::from_be_bytes(data[*position..*position + 1].try_into()?);
+        *position += 1;
+        let preference = u8::from_be_bytes(data[*position..*position + 1].try_into()?);
+        *position += 1;
+        let flags = CharacterString::parse(data, position)?;
+        let services = CharacterString::parse(data, position)?;
+        let regexp = CharacterString::parse(data, position)?;
+        let replacement = Name::parse(data, position)?;
+
+        Ok(Self { order, preference, flags, services, regexp, replacement})
+    }
+
+    fn write_to<T: std::io::Write>(&self, out: &mut T) -> crate::Result<()> {
+        out.write_all(&self.order.to_be_bytes())?;
+        out.write_all(&self.preference.to_be_bytes())?;
+        self.flags.write_to(out)?;
+        self.services.write_to(out)?;
+        self.regexp.write_to(regexp)?;
+        self.replacement.write_to(out)
+    }
+
+    fn len(&self) -> usize {
+        self.flags.len() + self.services.len() + self.regexp.len() + self.replacement.len() + 4
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_and_write_naptr() {
+        let naptr = NAPTR {
+            order: 0,
+            preference: 1,
+            flags: CharacterString::new(b"123abc").unwrap(),
+            services: CharacterString::new(b"test").unwrap(),
+            regexp: CharacterString::new(b"@\\w+\\.\\w{2,3}(\\.\\w{2,3})?").unwrap(),
+            replacement: Name::new("e.exchange.com").unwrap(),
+        };
+
+        let mut data = Vec::new();
+        assert!(naptr.write_to(&mut data).is_ok());
+
+        let naptr = NAPTR::parse(&data, &mut 0);
+        assert!(naptr.is_ok());
+        let naptr = naptr.unwrap();
+
+        assert_eq!(data.len(), naptr.len());
+        assert_eq!(0, naptr.order);
+        assert_eq!(1, naptr.preference);
+        assert_eq!("123abc", naptr.flags.to_string());
+        assert_eq!("test", naptr.services.to_string());
+        assert_eq!("@\\w+\\.\\w{2,3}(\\.\\w{2,3})?", naptr.regexp.to_string());
+        assert_eq!("e.exchange.com", naptr.value.to_string());
+    }
+}

--- a/simple-dns/src/dns/rdata/naptr.rs
+++ b/simple-dns/src/dns/rdata/naptr.rs
@@ -47,10 +47,10 @@ impl<'a> PacketPart<'a> for NAPTR<'a> {
     where
         Self: Sized,
     {
-        let order = u16::from_be_bytes(data[*position..*position + 1].try_into()?);
-        *position += 1;
-        let preference = u16::from_be_bytes(data[*position..*position + 1].try_into()?);
-        *position += 1;
+        let order = u16::from_be_bytes(data[*position..*position + 2].try_into()?);
+        *position += 2;
+        let preference = u16::from_be_bytes(data[*position..*position + 2].try_into()?);
+        *position += 2;
         let flags = CharacterString::parse(data, position)?;
         let services = CharacterString::parse(data, position)?;
         let regexp = CharacterString::parse(data, position)?;


### PR DESCRIPTION
Hello, I work with @berlin-with0ut-return who [added CAA support a few months ago](https://github.com/balliegojr/simple-dns/pull/18). We are hoping to add NAPTR support as well [(RFC 3403)](https://www.rfc-editor.org/rfc/rfc3403). Please let me know if anything looks off. We only need basic parsing for our use case.