### PR TITLE
Check data length in the A::parse() function

### DIFF
--- a/simple-dns/src/dns/rdata/a.rs
+++ b/simple-dns/src/dns/rdata/a.rs
@@ -19,6 +19,10 @@ impl<'a> PacketPart<'a> for A {
     where
         Self: Sized,
     {
+        if data.len() < *position + 4 {
+            return Err(crate::SimpleDnsError::InsufficientData);
+        }
+
         let address = u32::from_be_bytes(data[*position..*position + 4].try_into()?);
         *position += 4;
         Ok(Self { address })


### PR DESCRIPTION
We faced a panic in this slice indexing: `data[*position..*position + 4]` so I added length check.