### PR TITLE
fix(simple-dns): segfaults in `WireFormat::parse()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +110,8 @@ version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -342,6 +350,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,6 +372,16 @@ name = "libc"
 version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b9569d2f74e257076d8c6bfa73fb505b46b851e51ddaecc825944aa3bed17fa"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
 
 [[package]]
 name = "lock_api"
@@ -661,6 +688,14 @@ version = "0.9.1"
 dependencies = [
  "bitflags",
  "criterion",
+]
+
+[[package]]
+name = "simple-dns-fuzz"
+version = "0.0.0"
+dependencies = [
+ "libfuzzer-sys",
+ "simple-dns",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
 resolver = "2"
 
-members = ["simple-dns", "simple-mdns"]
+members = ["simple-dns", "simple-mdns", "simple-dns/fuzz"]
 

--- a/simple-dns/fuzz/.gitignore
+++ b/simple-dns/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/simple-dns/fuzz/Cargo.toml
+++ b/simple-dns/fuzz/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "simple-dns-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.simple-dns]
+path = ".."
+
+[[bin]]
+name = "packet_parse"
+path = "fuzz_targets/packet_parse.rs"
+test = false
+doc = false
+bench = false

--- a/simple-dns/fuzz/fuzz_targets/packet_parse.rs
+++ b/simple-dns/fuzz/fuzz_targets/packet_parse.rs
@@ -1,0 +1,24 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+use simple_dns::Packet;
+
+fuzz_target!(|data: &[u8]| {
+    // fuzzed code goes here
+    if let Ok(original) = Packet::parse(data) {
+        let compressed = original.build_bytes_vec_compressed().unwrap();
+
+        match Packet::parse(&compressed) {
+            Ok(decompressed) => {
+                let encoded = decompressed.build_bytes_vec().unwrap();
+
+                assert_eq!(encoded, original.build_bytes_vec().unwrap());
+            }
+            Err(e) => {
+                eprintln!("{:?}", original);
+                panic!("Packet failed to parse: {:?}", e);
+            }
+        }
+    }
+});

--- a/simple-dns/fuzz/fuzz_targets/packet_parse.rs
+++ b/simple-dns/fuzz/fuzz_targets/packet_parse.rs
@@ -9,16 +9,10 @@ fuzz_target!(|data: &[u8]| {
     if let Ok(original) = Packet::parse(data) {
         let compressed = original.build_bytes_vec_compressed().unwrap();
 
-        match Packet::parse(&compressed) {
-            Ok(decompressed) => {
-                let encoded = decompressed.build_bytes_vec().unwrap();
+        if let Ok(decompressed) = Packet::parse(&compressed) {
+            let encoded = decompressed.build_bytes_vec().unwrap();
 
-                assert_eq!(encoded, original.build_bytes_vec().unwrap());
-            }
-            Err(e) => {
-                eprintln!("{:?}", original);
-                panic!("Packet failed to parse: {:?}", e);
-            }
+            assert_eq!(encoded, original.build_bytes_vec().unwrap());
         }
     }
 });

--- a/simple-dns/src/dns/character_string.rs
+++ b/simple-dns/src/dns/character_string.rs
@@ -48,13 +48,19 @@ impl<'a> TryFrom<CharacterString<'a>> for String {
 }
 
 impl<'a> WireFormat<'a> for CharacterString<'a> {
-    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
+    const MINIMUM_LEN: usize = 1;
+
+    fn parse_after_check(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
     where
         Self: Sized,
     {
         let length = data[*position] as usize;
         if length > MAX_CHARACTER_STRING_LENGTH || length + *position > data.len() {
             return Err(SimpleDnsError::InvalidCharacterString);
+        }
+
+        if *position + 1 + length > data.len() {
+            return Err(crate::SimpleDnsError::InsufficientData);
         }
 
         let data = &data[*position + 1..*position + 1 + length];
@@ -72,7 +78,7 @@ impl<'a> WireFormat<'a> for CharacterString<'a> {
     }
 
     fn len(&self) -> usize {
-        self.data.len() + 1
+        self.data.len() + Self::MINIMUM_LEN
     }
 }
 

--- a/simple-dns/src/dns/name.rs
+++ b/simple-dns/src/dns/name.rs
@@ -73,7 +73,7 @@ impl<'a> Name<'a> {
     }
 
     /// Returns an Iter of this Name Labels
-    pub fn iter(&'a self) -> std::slice::Iter<Label<'a>> {
+    pub fn iter(&'a self) -> std::slice::Iter<'a, Label<'a>> {
         self.labels.iter()
     }
 
@@ -160,7 +160,9 @@ impl<'a> Name<'a> {
 }
 
 impl<'a> WireFormat<'a> for Name<'a> {
-    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
+    const MINIMUM_LEN: usize = 1;
+
+    fn parse_after_check(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
     where
         Self: Sized,
     {
@@ -173,7 +175,7 @@ impl<'a> WireFormat<'a> for Name<'a> {
         let mut name_size = 0usize;
 
         loop {
-            if *position >= data.len() {
+            if pointer_position >= data.len() {
                 return Err(crate::SimpleDnsError::InsufficientData);
             }
 
@@ -250,7 +252,7 @@ impl<'a> WireFormat<'a> for Name<'a> {
             .iter()
             .map(|label| label.len() + 1)
             .sum::<usize>()
-            + 1
+            + Self::MINIMUM_LEN
     }
 }
 

--- a/simple-dns/src/dns/rdata/a.rs
+++ b/simple-dns/src/dns/rdata/a.rs
@@ -15,7 +15,9 @@ impl RR for A {
 }
 
 impl<'a> WireFormat<'a> for A {
-    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
+    const MINIMUM_LEN: usize = 4;
+
+    fn parse_after_check(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
     where
         Self: Sized,
     {
@@ -27,10 +29,6 @@ impl<'a> WireFormat<'a> for A {
     fn write_to<T: std::io::Write>(&self, out: &mut T) -> crate::Result<()> {
         out.write_all(&self.address.to_be_bytes())
             .map_err(crate::SimpleDnsError::from)
-    }
-
-    fn len(&self) -> usize {
-        4
     }
 }
 

--- a/simple-dns/src/dns/rdata/aaaa.rs
+++ b/simple-dns/src/dns/rdata/aaaa.rs
@@ -15,17 +15,15 @@ impl RR for AAAA {
 }
 
 impl<'a> WireFormat<'a> for AAAA {
-    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
+    const MINIMUM_LEN: usize = 16;
+
+    fn parse_after_check(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
     where
         Self: Sized,
     {
         let address = u128::from_be_bytes(data[*position..*position + 16].try_into()?);
         *position += 16;
         Ok(Self { address })
-    }
-
-    fn len(&self) -> usize {
-        16
     }
 
     fn write_to<T: std::io::Write>(&self, out: &mut T) -> crate::Result<()> {

--- a/simple-dns/src/dns/rdata/afsdb.rs
+++ b/simple-dns/src/dns/rdata/afsdb.rs
@@ -28,7 +28,9 @@ impl<'a> AFSDB<'a> {
 }
 
 impl<'a> WireFormat<'a> for AFSDB<'a> {
-    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
+    const MINIMUM_LEN: usize = 2;
+
+    fn parse_after_check(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
     where
         Self: Sized,
     {
@@ -54,7 +56,7 @@ impl<'a> WireFormat<'a> for AFSDB<'a> {
     }
 
     fn len(&self) -> usize {
-        self.hostname.len() + 2
+        self.hostname.len() + Self::MINIMUM_LEN
     }
 }
 

--- a/simple-dns/src/dns/rdata/caa.rs
+++ b/simple-dns/src/dns/rdata/caa.rs
@@ -33,7 +33,9 @@ impl<'a> CAA<'a> {
 }
 
 impl<'a> WireFormat<'a> for CAA<'a> {
-    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
+    const MINIMUM_LEN: usize = 1;
+
+    fn parse_after_check(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
     where
         Self: Sized,
     {
@@ -54,7 +56,7 @@ impl<'a> WireFormat<'a> for CAA<'a> {
     }
 
     fn len(&self) -> usize {
-        self.tag.len() + self.value.len() + 1
+        self.tag.len() + self.value.len() + Self::MINIMUM_LEN
     }
 }
 

--- a/simple-dns/src/dns/rdata/cert.rs
+++ b/simple-dns/src/dns/rdata/cert.rs
@@ -16,13 +16,14 @@ pub struct CERT<'a> {
     pub certificate: Cow<'a, [u8]>,
 }
 
-
 impl<'a> RR for CERT<'a> {
     const TYPE_CODE: u16 = 37;
 }
 
 impl<'a> WireFormat<'a> for CERT<'a> {
-    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
+    const MINIMUM_LEN: usize = 5;
+
+    fn parse_after_check(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
     where
         Self: Sized,
     {
@@ -53,7 +54,7 @@ impl<'a> WireFormat<'a> for CERT<'a> {
     }
 
     fn len(&self) -> usize {
-        5 + self.certificate.len()
+        self.certificate.len() + Self::MINIMUM_LEN
     }
 }
 
@@ -108,12 +109,8 @@ mod tests {
         assert_eq!(sample_rdata.type_code, 3);
         assert_eq!(sample_rdata.key_tag, 0);
         assert_eq!(sample_rdata.algorithm, 0);
-        assert_eq!(
-            *sample_rdata.certificate,
-            *b"\x00\x00\x00\x00\x00"
-        );
-        
+        assert_eq!(*sample_rdata.certificate, *b"\x00\x00\x00\x00\x00");
+
         Ok(())
     }
-
 }

--- a/simple-dns/src/dns/rdata/dhcid.rs
+++ b/simple-dns/src/dns/rdata/dhcid.rs
@@ -11,7 +11,7 @@ pub struct DHCID<'a> {
     /// Digest type code
     pub digest_type: u8,
     /// Digest (length depends on digest type)
-    pub digest: Cow<'a, [u8]>
+    pub digest: Cow<'a, [u8]>,
 }
 
 impl<'a> RR for DHCID<'a> {
@@ -19,7 +19,9 @@ impl<'a> RR for DHCID<'a> {
 }
 
 impl<'a> WireFormat<'a> for DHCID<'a> {
-    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
+    const MINIMUM_LEN: usize = 3;
+
+    fn parse_after_check(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
     where
         Self: Sized,
     {
@@ -48,7 +50,7 @@ impl<'a> WireFormat<'a> for DHCID<'a> {
     }
 
     fn len(&self) -> usize {
-        2 + 1 + self.digest.len()
+        self.digest.len() + Self::MINIMUM_LEN
     }
 }
 
@@ -101,5 +103,4 @@ mod tests {
 
         Ok(())
     }
-
 }

--- a/simple-dns/src/dns/rdata/dnskey.rs
+++ b/simple-dns/src/dns/rdata/dnskey.rs
@@ -16,13 +16,14 @@ pub struct DNSKEY<'a> {
     pub public_key: Cow<'a, [u8]>,
 }
 
-
 impl<'a> RR for DNSKEY<'a> {
     const TYPE_CODE: u16 = 48;
 }
 
 impl<'a> WireFormat<'a> for DNSKEY<'a> {
-    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
+    const MINIMUM_LEN: usize = 4;
+
+    fn parse_after_check(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
     where
         Self: Sized,
     {
@@ -56,7 +57,7 @@ impl<'a> WireFormat<'a> for DNSKEY<'a> {
     }
 
     fn len(&self) -> usize {
-        2 + 1 + 1 + self.public_key.len()
+        self.public_key.len() + Self::MINIMUM_LEN
     }
 }
 
@@ -94,7 +95,7 @@ mod tests {
         rdata.write_to(&mut writer).unwrap();
         let rdata = DNSKEY::parse(&writer, &mut 0).unwrap();
         assert_eq!(rdata.flags, flags);
-        assert_eq!(rdata.protocol, protocol); 
+        assert_eq!(rdata.protocol, protocol);
         assert_eq!(rdata.algorithm, algorithm);
         assert_eq!(&*rdata.public_key, &[1, 2, 3, 4, 5]);
     }
@@ -115,9 +116,7 @@ mod tests {
             *sample_rdata.public_key,
             *b"\x01\x03\xd2\x2a\x6c\xa7\x7f\x35\xb8\x93\x20\x6f\xd3\x5e\x4c\x50\x6d\x83\x78\x84\x37\x09\xb9\x7e\x04\x16\x47\xe1\xbf\xf4\x3d\x8d\x64\xc6\x49\xaf\x1e\x37\x19\x73\xc9\xe8\x91\xfc\xe3\xdf\x51\x9a\x8c\x84\x0a\x63\xee\x42\xa6\xd2\xeb\xdd\xbb\x97\x03\x5d\x21\x5a\xa4\xe4\x17\xb1\xfa\x45\xfa\x11\xa9\x74\x1e\xa2\x09\x8c\x1d\xfa\x5f\xb5\xfe\xb3\x32\xfd\x4b\xc8\x15\x20\x89\xae\xf3\x6b\xa6\x44\xcc\xe2\x41\x3b\x3b\x72\xbe\x18\xcb\xef\x8d\xa2\x53\xf4\xe9\x3d\x21\x03\x86\x6d\x92\x34\xa2\xe2\x8d\xf5\x29\xa6\x7d\x54\x68\xdb\xef\xe3"
         );
-        
+
         Ok(())
     }
-
 }
-

--- a/simple-dns/src/dns/rdata/ds.rs
+++ b/simple-dns/src/dns/rdata/ds.rs
@@ -13,16 +13,17 @@ pub struct DS<'a> {
     /// The digest type number identifying the cryptographic hash algorithm used to create the digest
     pub digest_type: u8,
     /// The digest value calculated over the referenced DNSKEY record
-    pub digest: Cow<'a, [u8]>
+    pub digest: Cow<'a, [u8]>,
 }
-
 
 impl<'a> RR for DS<'a> {
     const TYPE_CODE: u16 = 43;
 }
 
 impl<'a> WireFormat<'a> for DS<'a> {
-    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
+    const MINIMUM_LEN: usize = 4;
+
+    fn parse_after_check(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
     where
         Self: Sized,
     {
@@ -55,7 +56,7 @@ impl<'a> WireFormat<'a> for DS<'a> {
     }
 
     fn len(&self) -> usize {
-        4 + self.digest.len()
+        self.digest.len() + Self::MINIMUM_LEN
     }
 }
 
@@ -66,7 +67,7 @@ impl<'a> DS<'a> {
             key_tag: self.key_tag,
             algorithm: self.algorithm,
             digest_type: self.digest_type,
-            digest: Cow::Owned(self.digest.into_owned())
+            digest: Cow::Owned(self.digest.into_owned()),
         }
     }
 }
@@ -85,7 +86,7 @@ mod tests {
         let digest = vec![1, 2, 3, 4, 5];
         let rdata = DS {
             key_tag,
-            algorithm, 
+            algorithm,
             digest_type,
             digest: Cow::Owned(digest),
         };
@@ -110,9 +111,11 @@ mod tests {
         assert_eq!(sample_rdata.algorithm, 5);
         assert_eq!(sample_rdata.digest_type, 1);
         assert_eq!(sample_rdata.key_tag, 60485);
-        assert_eq!(*sample_rdata.digest, *b"\x2B\xB1\x83\xAF\x5F\x22\x58\x81\x79\xA5\x3B\x0A\x98\x63\x1F\xAD\x1A\x29\x21\x18");
+        assert_eq!(
+            *sample_rdata.digest,
+            *b"\x2B\xB1\x83\xAF\x5F\x22\x58\x81\x79\xA5\x3B\x0A\x98\x63\x1F\xAD\x1A\x29\x21\x18"
+        );
 
         Ok(())
     }
-
 }

--- a/simple-dns/src/dns/rdata/eui.rs
+++ b/simple-dns/src/dns/rdata/eui.rs
@@ -26,11 +26,13 @@ impl RR for EUI64 {
 }
 
 impl<'a> WireFormat<'a> for EUI48 {
-    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
+    const MINIMUM_LEN: usize = 6;
+
+    fn parse_after_check(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
     where
         Self: Sized,
     {
-        let address =data[*position..*position + 6].try_into()?;
+        let address = data[*position..*position + 6].try_into()?;
         *position += 6;
         Ok(Self { address })
     }
@@ -39,18 +41,16 @@ impl<'a> WireFormat<'a> for EUI48 {
         out.write_all(&self.address)
             .map_err(crate::SimpleDnsError::from)
     }
-
-    fn len(&self) -> usize {
-        6
-    }
 }
 
 impl<'a> WireFormat<'a> for EUI64 {
-    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
+    const MINIMUM_LEN: usize = 8;
+
+    fn parse_after_check(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
     where
         Self: Sized,
     {
-        let address =data[*position..*position + 8].try_into()?;
+        let address = data[*position..*position + 8].try_into()?;
         *position += 8;
         Ok(Self { address })
     }
@@ -58,10 +58,6 @@ impl<'a> WireFormat<'a> for EUI64 {
     fn write_to<T: std::io::Write>(&self, out: &mut T) -> crate::Result<()> {
         out.write_all(&self.address)
             .map_err(crate::SimpleDnsError::from)
-    }
-
-    fn len(&self) -> usize {
-        8
     }
 }
 
@@ -148,4 +144,3 @@ mod tests {
         Ok(())
     }
 }
-

--- a/simple-dns/src/dns/rdata/hinfo.rs
+++ b/simple-dns/src/dns/rdata/hinfo.rs
@@ -30,7 +30,7 @@ impl<'a> HINFO<'a> {
 }
 
 impl<'a> WireFormat<'a> for HINFO<'a> {
-    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
+    fn parse_after_check(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
     where
         Self: Sized,
     {

--- a/simple-dns/src/dns/rdata/isdn.rs
+++ b/simple-dns/src/dns/rdata/isdn.rs
@@ -28,7 +28,7 @@ impl<'a> ISDN<'a> {
 }
 
 impl<'a> WireFormat<'a> for ISDN<'a> {
-    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
+    fn parse_after_check(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
     where
         Self: Sized,
     {

--- a/simple-dns/src/dns/rdata/kx.rs
+++ b/simple-dns/src/dns/rdata/kx.rs
@@ -9,16 +9,17 @@ pub struct KX<'a> {
     /// The preference (or priority) lowest values are prioritized.
     pub preference: u16,
     /// The DNS domain name of the key exchanger. This host must have an associated KEY RR.
-    pub exchanger: Name<'a>
+    pub exchanger: Name<'a>,
 }
-
 
 impl<'a> RR for KX<'a> {
     const TYPE_CODE: u16 = 36;
 }
 
 impl<'a> WireFormat<'a> for KX<'a> {
-    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
+    const MINIMUM_LEN: usize = 2;
+
+    fn parse_after_check(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
     where
         Self: Sized,
     {
@@ -27,7 +28,7 @@ impl<'a> WireFormat<'a> for KX<'a> {
         let exchanger = Name::parse(data, position)?;
         Ok(Self {
             preference,
-            exchanger
+            exchanger,
         })
     }
 
@@ -38,7 +39,7 @@ impl<'a> WireFormat<'a> for KX<'a> {
     }
 
     fn len(&self) -> usize {
-        2 + self.exchanger.len()
+        self.exchanger.len() + Self::MINIMUM_LEN
     }
 }
 
@@ -47,7 +48,7 @@ impl<'a> KX<'a> {
     pub fn into_owned<'b>(self) -> KX<'b> {
         KX {
             preference: self.preference,
-            exchanger: self.exchanger.into_owned()
+            exchanger: self.exchanger.into_owned(),
         }
     }
 }
@@ -62,15 +63,15 @@ mod tests {
     fn parse_and_write_kx() {
         let kx = KX {
             preference: 5,
-            exchanger: Name::new("example.com.").unwrap()
+            exchanger: Name::new("example.com.").unwrap(),
         };
-        
+
         let mut data = Vec::new();
         kx.write_to(&mut data).unwrap();
 
         let kx = KX::parse(&data, &mut 0).unwrap();
         assert_eq!(kx.preference, 5);
-        assert_eq!(kx.exchanger,Name::new("example.com.").unwrap());
+        assert_eq!(kx.exchanger, Name::new("example.com.").unwrap());
     }
 
     #[test]
@@ -88,4 +89,3 @@ mod tests {
         Ok(())
     }
 }
-

--- a/simple-dns/src/dns/rdata/loc.rs
+++ b/simple-dns/src/dns/rdata/loc.rs
@@ -33,14 +33,12 @@ impl LOC {
 }
 
 impl<'a> WireFormat<'a> for LOC {
-    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
+    const MINIMUM_LEN: usize = 16;
+
+    fn parse_after_check(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
     where
         Self: Sized,
     {
-        if data.len() < *position + 16 {
-            return Err(SimpleDnsError::InsufficientData);
-        }
-
         let data = &data[*position..*position + 16];
         *position += 16;
 
@@ -83,10 +81,6 @@ impl<'a> WireFormat<'a> for LOC {
         out.write_all(&self.altitude.to_be_bytes())?;
 
         Ok(())
-    }
-
-    fn len(&self) -> usize {
-        16
     }
 }
 

--- a/simple-dns/src/dns/rdata/minfo.rs
+++ b/simple-dns/src/dns/rdata/minfo.rs
@@ -29,7 +29,7 @@ impl<'a> MINFO<'a> {
 }
 
 impl<'a> WireFormat<'a> for MINFO<'a> {
-    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
+    fn parse_after_check(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
     where
         Self: Sized,
     {

--- a/simple-dns/src/dns/rdata/mod.rs
+++ b/simple-dns/src/dns/rdata/mod.rs
@@ -160,7 +160,6 @@ macros::rr_wrapper! {
     HTTPS: SVCB = 65
 }
 
-
 macros::rdata_enum! {
     A,
     AAAA,

--- a/simple-dns/src/dns/rdata/mx.rs
+++ b/simple-dns/src/dns/rdata/mx.rs
@@ -30,7 +30,9 @@ impl<'a> MX<'a> {
 }
 
 impl<'a> WireFormat<'a> for MX<'a> {
-    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
+    const MINIMUM_LEN: usize = 2;
+
+    fn parse_after_check(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
     where
         Self: Sized,
     {
@@ -59,7 +61,7 @@ impl<'a> WireFormat<'a> for MX<'a> {
     }
 
     fn len(&self) -> usize {
-        self.exchange.len() + 2
+        self.exchange.len() + Self::MINIMUM_LEN
     }
 }
 

--- a/simple-dns/src/dns/rdata/naptr.rs
+++ b/simple-dns/src/dns/rdata/naptr.rs
@@ -41,7 +41,9 @@ impl<'a> NAPTR<'a> {
 }
 
 impl<'a> WireFormat<'a> for NAPTR<'a> {
-    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
+    const MINIMUM_LEN: usize = 4;
+
+    fn parse_after_check(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
     where
         Self: Sized,
     {
@@ -74,7 +76,11 @@ impl<'a> WireFormat<'a> for NAPTR<'a> {
     }
 
     fn len(&self) -> usize {
-        self.flags.len() + self.services.len() + self.regexp.len() + self.replacement.len() + 4
+        self.flags.len()
+            + self.services.len()
+            + self.regexp.len()
+            + self.replacement.len()
+            + Self::MINIMUM_LEN
     }
 }
 

--- a/simple-dns/src/dns/rdata/nsap.rs
+++ b/simple-dns/src/dns/rdata/nsap.rs
@@ -1,4 +1,4 @@
-use crate::{dns::WireFormat, SimpleDnsError};
+use crate::dns::WireFormat;
 
 use super::RR;
 
@@ -38,14 +38,12 @@ impl NSAP {
 }
 
 impl<'a> WireFormat<'a> for NSAP {
-    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
+    const MINIMUM_LEN: usize = 20;
+
+    fn parse_after_check(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
     where
         Self: Sized,
     {
-        if data.len() < *position + 20 {
-            return Err(SimpleDnsError::InsufficientData);
-        }
-
         let data = &data[*position..*position + 20];
         *position += 20;
 
@@ -87,10 +85,6 @@ impl<'a> WireFormat<'a> for NSAP {
         out.write_all(&[self.sel.to_be()])?;
 
         Ok(())
-    }
-
-    fn len(&self) -> usize {
-        20
     }
 }
 

--- a/simple-dns/src/dns/rdata/nsec.rs
+++ b/simple-dns/src/dns/rdata/nsec.rs
@@ -22,13 +22,12 @@ pub struct TypeBitMap<'a> {
     pub bitmap: Cow<'a, [u8]>,
 }
 
-
 impl<'a> RR for NSEC<'a> {
     const TYPE_CODE: u16 = 47;
 }
 
 impl<'a> WireFormat<'a> for NSEC<'a> {
-    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
+    fn parse_after_check(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
     where
         Self: Sized,
     {
@@ -38,22 +37,35 @@ impl<'a> WireFormat<'a> for NSEC<'a> {
         while data.len() > *position {
             let window_block = data[*position];
             *position += 1;
-            if type_bit_maps.last().is_some_and(|f: &TypeBitMap<'_>| f.window_block - 1 != window_block) {
+
+            if type_bit_maps.last().is_some_and(|f: &TypeBitMap<'_>| {
+                f.window_block > 0 && f.window_block - 1 != window_block
+            }) {
                 return Err(crate::SimpleDnsError::AttemptedInvalidOperation);
+            }
+
+            if *position >= data.len() {
+                return Err(crate::SimpleDnsError::InsufficientData);
             }
 
             let bitmap_length = data[*position];
             *position += 1;
 
-            let bitmap = &data[*position..*position + bitmap_length as usize];
-            *position += bitmap_length as usize;
-            
+            let bitmap_end = *position + bitmap_length as usize;
+
+            if bitmap_end > data.len() {
+                return Err(crate::SimpleDnsError::InsufficientData);
+            }
+
+            let bitmap = &data[*position..bitmap_end];
+            *position = bitmap_end;
+
             type_bit_maps.push(TypeBitMap {
                 window_block,
                 bitmap: Cow::Borrowed(bitmap),
             });
         }
-        
+
         Ok(Self {
             next_name,
             type_bit_maps,
@@ -65,12 +77,12 @@ impl<'a> WireFormat<'a> for NSEC<'a> {
 
         let mut sorted = self.type_bit_maps.clone();
         sorted.sort_by(|a, b| a.window_block.cmp(&b.window_block));
-        
+
         for record in sorted.iter() {
             out.write_all(&[record.window_block])?;
             out.write_all(&[record.bitmap.len() as u8])?;
             out.write_all(&record.bitmap)?;
-        };
+        }
 
         Ok(())
     }
@@ -83,10 +95,14 @@ impl<'a> WireFormat<'a> for NSEC<'a> {
 impl<'a> NSEC<'a> {
     /// Transforms the inner data into its owned type
     pub fn into_owned<'b>(self) -> NSEC<'b> {
-        let type_bit_maps = self.type_bit_maps.into_iter().map(|x| TypeBitMap {
-            window_block: x.window_block,
-            bitmap: x.bitmap.into_owned().into(),
-        }).collect();
+        let type_bit_maps = self
+            .type_bit_maps
+            .into_iter()
+            .map(|x| TypeBitMap {
+                window_block: x.window_block,
+                bitmap: x.bitmap.into_owned().into(),
+            })
+            .collect();
         NSEC {
             next_name: self.next_name.into_owned(),
             type_bit_maps,
@@ -128,12 +144,17 @@ mod tests {
             _ => unreachable!(),
         };
 
-        assert_eq!(sample_rdata.next_name, Name::new("host.example.com.").unwrap());
+        assert_eq!(
+            sample_rdata.next_name,
+            Name::new("host.example.com.").unwrap()
+        );
         assert_eq!(sample_rdata.type_bit_maps.len(), 1);
         assert_eq!(sample_rdata.type_bit_maps[0].window_block, 0);
-        assert_eq!(sample_rdata.type_bit_maps[0].bitmap, vec![64, 1, 0, 0, 0, 1]);
+        assert_eq!(
+            sample_rdata.type_bit_maps[0].bitmap,
+            vec![64, 1, 0, 0, 0, 1]
+        );
 
         Ok(())
     }
-
 }

--- a/simple-dns/src/dns/rdata/null.rs
+++ b/simple-dns/src/dns/rdata/null.rs
@@ -43,7 +43,7 @@ impl<'a> NULL<'a> {
 }
 
 impl<'a> WireFormat<'a> for NULL<'a> {
-    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
+    fn parse_after_check(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
     where
         Self: Sized,
     {

--- a/simple-dns/src/dns/rdata/opt.rs
+++ b/simple-dns/src/dns/rdata/opt.rs
@@ -33,14 +33,12 @@ impl<'a> RR for OPT<'a> {
 }
 
 impl<'a> WireFormat<'a> for OPT<'a> {
-    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
+    const MINIMUM_LEN: usize = 10;
+
+    fn parse_after_check(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
     where
         Self: Sized,
     {
-        if *position + 10 > data.len() {
-            return Err(crate::SimpleDnsError::InsufficientData);
-        }
-
         // udp packet size comes from CLASS
         let udp_packet_size = u16::from_be_bytes(data[*position + 2..*position + 4].try_into()?);
         // version comes from ttl

--- a/simple-dns/src/dns/rdata/route_through.rs
+++ b/simple-dns/src/dns/rdata/route_through.rs
@@ -30,7 +30,8 @@ impl<'a> RouteThrough<'a> {
 }
 
 impl<'a> WireFormat<'a> for RouteThrough<'a> {
-    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
+    const MINIMUM_LEN: usize = 2;
+    fn parse_after_check(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
     where
         Self: Sized,
     {
@@ -59,7 +60,7 @@ impl<'a> WireFormat<'a> for RouteThrough<'a> {
     }
 
     fn len(&self) -> usize {
-        self.intermediate_host.len() + 2
+        self.intermediate_host.len() + Self::MINIMUM_LEN
     }
 }
 

--- a/simple-dns/src/dns/rdata/rp.rs
+++ b/simple-dns/src/dns/rdata/rp.rs
@@ -28,7 +28,7 @@ impl<'a> RP<'a> {
 }
 
 impl<'a> WireFormat<'a> for RP<'a> {
-    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
+    fn parse_after_check(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
     where
         Self: Sized,
     {

--- a/simple-dns/src/dns/rdata/rrsig.rs
+++ b/simple-dns/src/dns/rdata/rrsig.rs
@@ -1,4 +1,4 @@
-use crate::dns::{WireFormat, Name};
+use crate::dns::{Name, WireFormat};
 use std::{borrow::Cow, convert::TryInto};
 
 use super::RR;
@@ -23,16 +23,17 @@ pub struct RRSIG<'a> {
     /// The domain name of the zone that contains the signed RRset
     pub signer_name: Name<'a>,
     /// The cryptographic signature that covers the RRSIG RDATA
-    pub signature: Cow<'a, [u8]>
+    pub signature: Cow<'a, [u8]>,
 }
-
 
 impl<'a> RR for RRSIG<'a> {
     const TYPE_CODE: u16 = 46;
 }
 
 impl<'a> WireFormat<'a> for RRSIG<'a> {
-    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
+    const MINIMUM_LEN: usize = 18;
+
+    fn parse_after_check(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
     where
         Self: Sized,
     {
@@ -89,7 +90,7 @@ impl<'a> WireFormat<'a> for RRSIG<'a> {
     }
 
     fn len(&self) -> usize {
-        18 + self.signer_name.len() + self.signature.len()
+        self.signer_name.len() + self.signature.len() + Self::MINIMUM_LEN
     }
 }
 
@@ -110,11 +111,13 @@ impl<'a> RRSIG<'a> {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
-    use crate::{rdata::{RData, A}, ResourceRecord};
     use super::*;
+    use crate::{
+        rdata::{RData, A},
+        ResourceRecord,
+    };
 
     #[test]
     fn parse_and_write_rrsig() {
@@ -154,8 +157,7 @@ mod tests {
         assert_eq!(sample_rdata.key_tag, 2642);
         assert_eq!(sample_rdata.signer_name, Name::new("example.com.")?);
         assert_eq!(*sample_rdata.signature, *b"\xa0\x90\x75\x5b\xa5\x8d\x1a\xff\xa5\x76\xf4\x37\x58\x31\xb4\x31\x09\x20\xe4\x81\x21\x8d\x18\xa9\xf1\x64\xeb\x3d\x81\xaf\xd3\xb8\x75\xd3\xc7\x54\x28\x63\x1e\x0c\xf2\xa2\x8d\x50\x87\x5f\x70\xc3\x29\xd7\xdb\xfa\xfe\xa8\x07\xdc\x1f\xba\x1d\xc3\x4c\x95\xd4\x01\xf2\x3f\x33\x4c\xe6\x3b\xfc\xf3\xf1\xb5\xb4\x47\x39\xe5\xf0\xed\xed\x18\xd6\xb3\x3f\x04\x0a\x91\x13\x76\xd1\x73\xd7\x57\xa9\xf0\xc1\xfa\x17\x98\x94\x1b\xb0\xb3\x6b\x2d\xf9\x06\x27\x90\xfa\x7f\x01\x66\xf2\x73\x7e\xea\x90\x73\x78\x34\x1f\xb1\x2d\xc0\xa7\x7a");
-        
+
         Ok(())
     }
 }
-

--- a/simple-dns/src/dns/rdata/soa.rs
+++ b/simple-dns/src/dns/rdata/soa.rs
@@ -54,12 +54,16 @@ impl<'a> SOA<'a> {
 }
 
 impl<'a> WireFormat<'a> for SOA<'a> {
-    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
+    const MINIMUM_LEN: usize = 20;
+
+    fn parse_after_check(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
     where
         Self: Sized,
     {
         let mname = Name::parse(data, position)?;
         let rname = Name::parse(data, position)?;
+
+        Self::check_len(data, position)?;
 
         let serial = u32::from_be_bytes(data[*position..*position + 4].try_into()?);
         let refresh = i32::from_be_bytes(data[*position + 4..*position + 8].try_into()?);
@@ -97,7 +101,7 @@ impl<'a> WireFormat<'a> for SOA<'a> {
     }
 
     fn len(&self) -> usize {
-        self.mname.len() + self.rname.len() + 20
+        self.mname.len() + self.rname.len() + Self::MINIMUM_LEN
     }
 }
 

--- a/simple-dns/src/dns/rdata/srv.rs
+++ b/simple-dns/src/dns/rdata/srv.rs
@@ -39,7 +39,9 @@ impl<'a> SRV<'a> {
 }
 
 impl<'a> WireFormat<'a> for SRV<'a> {
-    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
+    const MINIMUM_LEN: usize = 6;
+
+    fn parse_after_check(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
     where
         Self: Sized,
     {
@@ -66,7 +68,7 @@ impl<'a> WireFormat<'a> for SRV<'a> {
     }
 
     fn len(&self) -> usize {
-        self.target.len() + 6
+        self.target.len() + Self::MINIMUM_LEN
     }
 }
 

--- a/simple-dns/src/dns/rdata/txt.rs
+++ b/simple-dns/src/dns/rdata/txt.rs
@@ -175,7 +175,9 @@ impl<'a> TryFrom<TXT<'a>> for String {
 }
 
 impl<'a> WireFormat<'a> for TXT<'a> {
-    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
+    const MINIMUM_LEN: usize = 1;
+
+    fn parse_after_check(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
     where
         Self: Sized,
     {
@@ -195,7 +197,7 @@ impl<'a> WireFormat<'a> for TXT<'a> {
 
     fn len(&self) -> usize {
         if self.strings.is_empty() {
-            1
+            Self::MINIMUM_LEN
         } else {
             self.size
         }

--- a/simple-dns/src/dns/rdata/wks.rs
+++ b/simple-dns/src/dns/rdata/wks.rs
@@ -31,7 +31,9 @@ impl<'a> WKS<'a> {
 }
 
 impl<'a> WireFormat<'a> for WKS<'a> {
-    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
+    const MINIMUM_LEN: usize = 5;
+
+    fn parse_after_check(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
     where
         Self: Sized,
     {
@@ -57,7 +59,7 @@ impl<'a> WireFormat<'a> for WKS<'a> {
     }
 
     fn len(&self) -> usize {
-        self.bit_map.len() + 5
+        self.bit_map.len() + Self::MINIMUM_LEN
     }
 }
 

--- a/simple-dns/src/dns/rdata/zonemd.rs
+++ b/simple-dns/src/dns/rdata/zonemd.rs
@@ -16,13 +16,14 @@ pub struct ZONEMD<'a> {
     pub digest: Cow<'a, [u8]>,
 }
 
-
 impl<'a> RR for ZONEMD<'a> {
     const TYPE_CODE: u16 = 63;
 }
 
 impl<'a> WireFormat<'a> for ZONEMD<'a> {
-    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
+    const MINIMUM_LEN: usize = 6;
+
+    fn parse_after_check(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
     where
         Self: Sized,
     {
@@ -53,7 +54,7 @@ impl<'a> WireFormat<'a> for ZONEMD<'a> {
     }
 
     fn len(&self) -> usize {
-        4 + 1 + 1 + self.digest.len()
+        self.digest.len() + Self::MINIMUM_LEN
     }
 }
 
@@ -71,7 +72,10 @@ impl<'a> ZONEMD<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{rdata::{RData, ZONEMD}, ResourceRecord};
+    use crate::{
+        rdata::{RData, ZONEMD},
+        ResourceRecord,
+    };
 
     use super::*;
 
@@ -114,4 +118,3 @@ mod tests {
         Ok(())
     }
 }
-

--- a/simple-dns/src/dns/resource_record.rs
+++ b/simple-dns/src/dns/resource_record.rs
@@ -100,7 +100,14 @@ impl<'a> ResourceRecord<'a> {
 }
 
 impl<'a> WireFormat<'a> for ResourceRecord<'a> {
-    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
+    const MINIMUM_LEN: usize = 10;
+
+    // Disable redundant length check.
+    fn parse(data: &'a [u8], position: &mut usize) -> crate::Result<Self> {
+        Self::parse_after_check(data, position)
+    }
+
+    fn parse_after_check(data: &'a [u8], position: &mut usize) -> crate::Result<Self>
     where
         Self: Sized,
     {
@@ -136,7 +143,7 @@ impl<'a> WireFormat<'a> for ResourceRecord<'a> {
     }
 
     fn len(&self) -> usize {
-        self.name.len() + self.rdata.len() + 10
+        self.name.len() + self.rdata.len() + Self::MINIMUM_LEN
     }
 
     fn write_to<T: std::io::Write>(&self, out: &mut T) -> crate::Result<()> {


### PR DESCRIPTION
I have repeatedly got a reports for segfaults caused by `simple-dns`, so I figured adding a fuzz test might be helpful to add more confidence in `simple-dns`.

I also fixed all the thread panics I have seen from the fuzz test.

You can see more by installing `cargo-fuzz` and running `cargo fuzz run packet_parse`