### PR TITLE
Adding MDNS A/AAAA resolution based on hostname

### DIFF
--- a/simple-mdns/Cargo.toml
+++ b/simple-mdns/Cargo.toml
@@ -19,7 +19,7 @@ async-tokio = ["dep:tokio"]
 
 [dependencies]
 simple-dns = { path = "../simple-dns", version = "0.*" }
-socket2 = { version = "0.5", features = ["all"] }
+socket2 = { version = "0.6", features = ["all"] }
 log = "^0.4"
 radix_trie = "^0.3.0"
 tokio = { version = "1.32", features = [
@@ -29,6 +29,7 @@ tokio = { version = "1.32", features = [
     "time",
     "macros",
 ], optional = true, default-features = false }
+socket-pktinfo = "0.4.0"
 
 [dev-dependencies]
 stderrlog = "0.6"

--- a/simple-mdns/README.md
+++ b/simple-mdns/README.md
@@ -119,5 +119,34 @@ IPV6 is now supported by using the `NetworkScope` enum.
     # }
 ```
 
+## MDNS Hostname A/AAAA Resolve
+
+IP address (A/AAAA) resolution based on Hostname.local (without discovery)
+
+```rust  
+     use simple_mdns::sync_hostname_resolver::OneShotMdnsHostnameResolver;
+
+
+     let mut resolver = OneShotMdnsHostnameResolver::new().expect("Failed to create resolver");
+     let answer = resolver.query_hostname_address("volumio.local");
+         let result = match answer {
+             Ok(result) => match result {
+                 Some(addr) => addr,
+                 None => {
+                     println!("No answer found for the hostname");
+                     std::process::exit(0);
+                 }
+             },
+             Err(err) => {
+                 println!("err {}", err);
+                 std::process::exit(0);
+             }
+         };
+         for ip in result.ip_addresses {
+             println!("IP address: {}", ip);
+             
+         }
+         println!("scope: {}", result.scope);
+```
 
 Note: It is not tested on MacOS.

--- a/simple-mdns/src/lib.rs
+++ b/simple-mdns/src/lib.rs
@@ -25,6 +25,8 @@ pub mod async_discovery;
 
 #[cfg(feature = "sync")]
 pub mod sync_discovery;
+#[cfg(feature = "sync")]
+pub mod sync_hostname_resolver;
 
 #[allow(unused)]
 const UNICAST_RESPONSE: bool = cfg!(not(test));

--- a/simple-mdns/src/sync_hostname_resolver/mod.rs
+++ b/simple-mdns/src/sync_hostname_resolver/mod.rs
@@ -1,0 +1,3 @@
+mod sync_hostname_resolver;
+
+pub use sync_hostname_resolver::OneShotMdnsHostnameResolver;

--- a/simple-mdns/src/sync_hostname_resolver/sync_hostname_resolver.rs
+++ b/simple-mdns/src/sync_hostname_resolver/sync_hostname_resolver.rs
@@ -1,0 +1,198 @@
+
+use crate::{
+    NetworkScope, SimpleMdnsError, UNICAST_RESPONSE, socket_helper::join_multicast_with_pktinfo
+};
+use simple_dns::{header_buffer, rdata::RData, Name, Packet, Question, CLASS, TYPE};
+
+use std::{
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    time::{Duration, Instant},
+};
+use socket_pktinfo::{PktInfo, PktInfoUdpSocket};
+
+/// Provides One Shot hostname A or AAAA resolution queries (legacy mDNS)
+///
+/// Every query will timeout after `query_timeout` elapses (defaults to 3 seconds)
+///
+/// One Shot queries returns only the first valid response to arrive
+/// ```
+///     use simple_mdns::sync_hostname_resolver::OneShotMdnsHostnameResolver;
+///
+///
+///     let mut resolver = OneShotMdnsHostnameResolver::new().expect("Failed to create resolver");
+///     let answer = resolver.query_hostname_address("volumio.local");
+///         let result = match answer {
+///             Ok(result) => match result {
+///                 Some(addr) => addr,
+///                 None => {
+///                     println!("No answer found for the hostname");
+///                     std::process::exit(0);
+///                 }
+///             },
+///             Err(err) => {
+///                 println!("err {}", err);
+///                 std::process::exit(0);
+///             }
+///         };
+///         for ip in result.ip_addresses {
+///             println!("IP address: {}", ip);
+///             
+///         }
+///         println!("scope: {}", result.scope);
+/// ```
+#[derive(Debug)]
+pub struct OneShotMdnsHostnameResolver {
+    query_timeout: Duration,
+    unicast_response: bool,
+    receiver_socket: PktInfoUdpSocket,
+    network_scope: NetworkScope,
+}
+
+pub struct HostnameResolveResult{
+    pub ip_addresses: Vec<IpAddr>,
+    pub scope: u64
+}
+impl OneShotMdnsHostnameResolver {
+    /// Creates a new OneShotMdnsResolver using IP V4 with unspecified interface
+    pub fn new() -> Result<Self, SimpleMdnsError> {
+        Self::new_with_scope(NetworkScope::V4)
+    }
+
+    /// Creates a new OneShotMdnsResolver with the specified scope
+    pub fn new_with_scope(network_scope: NetworkScope) -> Result<Self, SimpleMdnsError> {
+        Ok(Self {
+            query_timeout: Duration::from_secs(3),
+            unicast_response: UNICAST_RESPONSE,
+            network_scope,
+            receiver_socket: join_multicast_with_pktinfo(network_scope)?,
+        })
+    }
+
+    /// Send a query packet and returns the first response
+    pub fn query_packet(&self, packet: Packet) -> Result<(Option<Vec<u8>>, PktInfo), SimpleMdnsError> {
+        self.receiver_socket.send_to(
+            &packet.build_bytes_vec_compressed()?,
+            &self.network_scope.socket_address().into(),
+        )?;
+        let deadline = Instant::now() + self.query_timeout;
+        self.get_next_response(packet.id(), deadline)
+    }
+
+    /// Send a query for A or AAAA (IP v4 and v6 respectively) resources and return the first address with network interface scope id
+    pub fn query_hostname_address(
+        &self,
+        hostname: &str,
+    ) -> Result<Option<HostnameResolveResult>, SimpleMdnsError> {
+        let mut packet = Packet::new_query(0);
+        let hostname = Name::new(hostname)?;
+        let mut result = HostnameResolveResult{
+            ip_addresses: Vec::new(),
+            scope: 0
+        };
+        packet.questions.push(Question::new(
+            hostname.clone(),
+            TYPE::A.into(),
+            CLASS::IN.into(),
+            self.unicast_response,
+        ));
+
+        self.receiver_socket.send_to(
+            &packet.build_bytes_vec_compressed()?,
+            &self.network_scope.socket_address().into(),
+        )?;
+
+        let deadline = Instant::now() + self.query_timeout;
+        loop {
+            let (buffer, pkt_info) = match self.get_next_response(packet.id(), deadline) {
+                Ok((Some(buffer), pkt_info)) => {
+                    (buffer, pkt_info)
+                },
+                Ok((None, _)) => {
+                    break
+                },
+                Err(err) => {
+                    log::error!("Received invalid packet: {}", err);
+                    continue;
+                }
+            };
+
+            let response = match Packet::parse(&buffer) {
+                Ok(packet) => packet,
+                Err(err) => {
+                    log::error!("Received invalid packet: {}", err);
+                    continue;
+                }
+            };
+
+            for anwser in response.answers {
+                if anwser.name != hostname {
+                    continue;
+                }
+                println!("Found matching answer: {:?}", anwser);
+                match anwser.rdata {
+                    RData::A(a) => {
+                        result.ip_addresses.push(IpAddr::V4(Ipv4Addr::from(a.address)));
+                    },
+                    RData::AAAA(aaaa) => {
+                        result.ip_addresses.push(IpAddr::V6(Ipv6Addr::from(aaaa.address)));
+                    },
+                    _ => continue,
+                };
+
+            }
+            for anwser in response.additional_records {
+                if anwser.name != hostname {
+                    continue;
+                }
+                println!("Found matching additional_records: {:?}", anwser);
+                match anwser.rdata {
+                    RData::A(a) => {
+                        result.ip_addresses.push(IpAddr::V4(Ipv4Addr::from(a.address)));
+                    },
+                    RData::AAAA(aaaa) => {
+                        result.ip_addresses.push(IpAddr::V6(Ipv6Addr::from(aaaa.address)));
+                    },
+                    _ => continue,
+                };
+            }
+            result.scope = pkt_info.if_index;
+            return Ok(Some(result));
+        }
+
+        Ok(None)
+    }
+    /// Set the one shot mdns resolver's query timeout.
+    pub fn set_query_timeout(&mut self, query_timeout: Duration) {
+        self.query_timeout = query_timeout;
+    }
+
+    /// Set the one shot mdns resolver's unicast response.
+    pub fn set_unicast_response(&mut self, unicast_response: bool) {
+        self.unicast_response = unicast_response;
+    }
+
+    fn get_next_response(
+        &self,
+        packet_id: u16,
+        query_deadline: std::time::Instant,
+    ) -> Result<(Option<Vec<u8>>, PktInfo), SimpleMdnsError> {
+        let mut buf = [0u8; 4096];
+        loop {
+            match self.receiver_socket.recv(&mut buf[..]) {
+                Ok((count,packt_info)) => {
+                    if header_buffer::has_flags(&buf, simple_dns::PacketFlag::RESPONSE)?
+                        && header_buffer::id(&buf)? == packet_id
+                        && header_buffer::answers(&buf)? > 0
+                    {
+                        return Ok((Some(buf[..count].to_vec()), packt_info));
+                    }
+                }
+                Err(_) => {
+                    if std::time::Instant::now() > query_deadline {
+                        return Err(SimpleMdnsError::ServiceDiscoveryStopped);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/simple-mdns/src/sync_hostname_resolver/sync_hostname_resolver.rs
+++ b/simple-mdns/src/sync_hostname_resolver/sync_hostname_resolver.rs
@@ -128,7 +128,6 @@ impl OneShotMdnsHostnameResolver {
                 if anwser.name != hostname {
                     continue;
                 }
-                println!("Found matching answer: {:?}", anwser);
                 match anwser.rdata {
                     RData::A(a) => {
                         result.ip_addresses.push(IpAddr::V4(Ipv4Addr::from(a.address)));
@@ -144,7 +143,6 @@ impl OneShotMdnsHostnameResolver {
                 if anwser.name != hostname {
                     continue;
                 }
-                println!("Found matching additional_records: {:?}", anwser);
                 match anwser.rdata {
                     RData::A(a) => {
                         result.ip_addresses.push(IpAddr::V4(Ipv4Addr::from(a.address)));

--- a/simple-mdns/tests/sync_resolver.rs
+++ b/simple-mdns/tests/sync_resolver.rs
@@ -1,0 +1,16 @@
+#![cfg(feature = "sync")]
+
+use simple_mdns::sync_hostname_resolver::OneShotMdnsHostnameResolver;
+
+
+
+#[test]
+fn sync_resolver_hostname() {
+    let mut resolver = OneShotMdnsHostnameResolver::new().expect("Failed to create resolver");
+    let answer = resolver.query_hostname_address("volumio.local");
+    
+    assert!(answer.is_ok());
+    resolver = OneShotMdnsHostnameResolver::new_with_scope( simple_mdns::NetworkScope::V6 ).expect("Failed to create resolver");
+    let answer = resolver.query_hostname_address("volumio.local");
+    assert!(answer.is_ok());
+}


### PR DESCRIPTION
Hello @balliegojr  !

I want to propose you this PR, which enable MDNS A/AAAA resolution based on the "hostname.local"

I use socket_pktinfo to get the interface ID which is usefull when the result is a link local IPv6 address

I wasn't able to get rid of warning: missing documentation for a module, please let me known how to fix this or if you have any comment ! 


Simon